### PR TITLE
Update cosign version and goreleaser template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   op: twdps/onepassword@1.0.0
-  cosign: twdps/cosign@0.1.0
+  cosign: twdps/cosign@0.1.1
   win: circleci/windows@4.1.1
 
 # =================================== global pipeline parameters
@@ -74,7 +74,8 @@ jobs:
       - op/install-op:
           os: Ubuntu
       - op/env
-      - cosign/install
+      - cosign/install:
+          cosign-version: v2.2.1
       - run:
           name: fetch keys for signing
           command: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,16 +16,16 @@ builds:
 signs:
   - cmd: cosign
     stdin: '{{ .Env.COSIGN_PWD }}'
-    args: ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
+    args: ["sign-blob", "--yes", "--key=cosign.key", "--output=${signature}", "${artifact}"]
     artifacts: all
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      linux: Linux
-      386: i386
-      amd64: x86_64
-      darwin: macOS
-      windows: Windows
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
      - goos: windows
        format: zip


### PR DESCRIPTION
**Summary**

This PR

- updates the cosign Orb used in the CircleCI pipeline to v0.1.1 to benefit from updates to the installer 
- passes an explicit version of the cosign CLI to install to the cosign/install Orb command
- runs the sign-blob CLI command in non-interactive mode
- updates some deprecated goreleaser syntax